### PR TITLE
Dockerfile.yml

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,3 +44,46 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C $BUILD_TYPE
+      - name: Build and push Docker images
+  # You may pin to the exact commit or the version.
+  # uses: docker/build-push-action@0db984c1826869dcd0740ff26ff75ff543238fd9
+  uses: docker/build-push-action@v2.2.1
+  with:
+    # Builder instance
+    builder: # optional
+    # Build's context is the set of files located in the specified PATH or URL
+    context: # optional
+    # Path to the Dockerfile
+    file: # optional, default is ./Dockerfile
+    # List of build-time variables
+    build-args: # optional
+    # List of metadata for an image
+    labels: # optional
+    # List of tags
+    tags: # optional
+    # Always attempt to pull a newer version of the image
+    pull: # optional, default is false
+    # Sets the target stage to build
+    target: # optional
+    # List of extra privileged entitlement (eg. network.host,security.insecure)
+    allow: # optional
+    # Do not use cache when building the image
+    no-cache: # optional, default is false
+    # List of target platforms for build
+    platforms: # optional
+    # Load is a shorthand for --output=type=docker
+    load: # optional, default is false
+    # Push is a shorthand for --output=type=registry
+    push: # optional, default is false
+    # List of output destinations (format: type=local,dest=path)
+    outputs: # optional
+    # List of external cache sources for buildx (eg. user/app:cache, type=local,src=path/to/dir)
+    cache-from: # optional
+    # List of cache export destinations for buildx (eg. user/app:cache, type=local,dest=path/to/dir)
+    cache-to: # optional
+    # List of secrets to expose to the build (eg. key=value, GIT_AUTH_TOKEN=mytoken)
+    secrets: # optional
+    # GitHub Token used to authenticate against a repository for Git context
+    github-token: # optional, default is ${{ github.token }}
+    # List of SSH agent socket or keys to expose to the build
+    ssh: # optional


### PR DESCRIPTION
- name: Build and push Docker images
  # You may pin to the exact commit or the version.
  # uses: docker/build-push-action@0db984c1826869dcd0740ff26ff75ff543238fd9
  uses: docker/build-push-action@v2.2.1
  with:
    # Builder instance
    builder: # optional
    # Build's context is the set of files located in the specified PATH or URL
    context: # optional
    # Path to the Dockerfile
    file: # optional, default is ./Dockerfile
    # List of build-time variables
    build-args: # optional
    # List of metadata for an image
    labels: # optional
    # List of tags
    tags: # optional
    # Always attempt to pull a newer version of the image
    pull: # optional, default is false
    # Sets the target stage to build
    target: # optional
    # List of extra privileged entitlement (eg. network.host,security.insecure)
    allow: # optional
    # Do not use cache when building the image
    no-cache: # optional, default is false
    # List of target platforms for build
    platforms: # optional
    # Load is a shorthand for --output=type=docker
    load: # optional, default is false
    # Push is a shorthand for --output=type=registry
    push: # optional, default is false
    # List of output destinations (format: type=local,dest=path)
    outputs: # optional
    # List of external cache sources for buildx (eg. user/app:cache, type=local,src=path/to/dir)
    cache-from: # optional
    # List of cache export destinations for buildx (eg. user/app:cache, type=local,dest=path/to/dir)
    cache-to: # optional
    # List of secrets to expose to the build (eg. key=value, GIT_AUTH_TOKEN=mytoken)
    secrets: # optional
    # GitHub Token used to authenticate against a repository for Git context
    github-token: # optional, default is ${{ github.token }}
    # List of SSH agent socket or keys to expose to the build
    ssh: # optional